### PR TITLE
Add Java runtime metadata contributor

### DIFF
--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/config/SpringBootAdminClientAutoConfiguration.java
@@ -63,6 +63,7 @@ import de.codecentric.boot.admin.client.registration.ServletApplicationFactory;
 import de.codecentric.boot.admin.client.registration.metadata.CompositeMetadataContributor;
 import de.codecentric.boot.admin.client.registration.metadata.MetadataContributor;
 import de.codecentric.boot.admin.client.registration.metadata.StartupDateMetadataContributor;
+import de.codecentric.boot.admin.client.registration.metadata.JavaVersionMetadataContributor;
 
 import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import static org.springframework.web.reactive.function.client.ExchangeFilterFunctions.basicAuthentication;
@@ -95,11 +96,17 @@ public class SpringBootAdminClientAutoConfiguration {
 		return listener;
 	}
 
-	@Bean
-	@ConditionalOnMissingBean
-	public StartupDateMetadataContributor startupDateMetadataContributor() {
-		return new StartupDateMetadataContributor();
-	}
+        @Bean
+        @ConditionalOnMissingBean
+        public StartupDateMetadataContributor startupDateMetadataContributor() {
+                return new StartupDateMetadataContributor();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public JavaVersionMetadataContributor javaVersionMetadataContributor() {
+                return new JavaVersionMetadataContributor();
+        }
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnWebApplication(type = Type.SERVLET)

--- a/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/metadata/JavaVersionMetadataContributor.java
+++ b/spring-boot-admin-client/src/main/java/de/codecentric/boot/admin/client/registration/metadata/JavaVersionMetadataContributor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.client.registration.metadata;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JavaVersionMetadataContributor implements MetadataContributor {
+
+    @Override
+    public Map<String, String> getMetadata() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("java.version", System.getProperty("java.version"));
+        metadata.put("java.vendor", System.getProperty("java.vendor"));
+        return metadata;
+    }
+
+}

--- a/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/metadata/JavaVersionMetadataContributorTest.java
+++ b/spring-boot-admin-client/src/test/java/de/codecentric/boot/admin/client/registration/metadata/JavaVersionMetadataContributorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.codecentric.boot.admin.client.registration.metadata;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaVersionMetadataContributorTest {
+
+        @Test
+        public void should_return_java_details() {
+                JavaVersionMetadataContributor contributor = new JavaVersionMetadataContributor();
+
+                Map<String, String> metadata = contributor.getMetadata();
+
+                assertThat(metadata).containsEntry("java.version", System.getProperty("java.version"))
+                                .containsEntry("java.vendor", System.getProperty("java.vendor"));
+        }
+
+}

--- a/spring-boot-admin-docs/src/site/docs/client/client-features.md
+++ b/spring-boot-admin-docs/src/site/docs/client/client-features.md
@@ -99,6 +99,12 @@ spring.boot.admin.client.instance.metadata.tags.environment=test
 info.tags.environment=test
 ```
 
+## Java Runtime Metadata
+
+The client automatically registers details about the running JVM. Each
+instance exposes the `java.version` and `java.vendor` metadata entries so
+the server can display the Java runtime used by the application.
+
 ## Spring Boot Admin Client
 
 The Spring Boot Admin Client registers the application at the admin server. This is done by periodically doing a HTTP post request to the SBA Server providing information about the application.


### PR DESCRIPTION
## Summary
- collect running Java version and vendor as metadata
- auto-configure the new contributor
- document the JVM metadata feature
- add unit test for `JavaVersionMetadataContributor`
- use `HashMap` instead of `LinkedHashMap`

## Testing
- `./mvnw -q -pl spring-boot-admin-client -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6864dd21e5e08333a4981bbf3d8345c8